### PR TITLE
[FEAT] plannings: index action

### DIFF
--- a/app/models/finance/transaction.rb
+++ b/app/models/finance/transaction.rb
@@ -2,6 +2,7 @@ class Finance::Transaction < ApplicationRecord
     validates :description, length: { maximum: 30 }
     validates :occurred_at, :description, :value, :finance_category_id, :currency, presence: true
 
+    belongs_to :user
     belongs_to :finance_category, class_name: "Finance::Category", foreign_key: "finance_category_id", dependent: :destroy
 
     scope :by_currency, ->(currency) { where(currency: currency) }

--- a/app/services/transactionsByRange.rb
+++ b/app/services/transactionsByRange.rb
@@ -1,0 +1,21 @@
+class TransactionsByRange
+  def initialize(user, currency, start_date, end_date=nil)
+    unless end_date
+      end_date = Date.today
+    end
+
+    @user = user
+    @currency = currency
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def get_total_amount
+    total = @user.finance_transactions.where(
+      currency: @currency,
+      occurred_at: @start_date..@end_date
+    ).sum(:value)
+
+    total.to_f
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   namespace :finance do
     resources :planning_lines
-    resources :plannings, only: [:create] do
+    resources :plannings, only: [:create, :index] do
       collection do
         get 'current'
       end

--- a/db/seeds/admin_account.rb
+++ b/db/seeds/admin_account.rb
@@ -48,7 +48,8 @@ categories = Finance::Category.create!([
 ])
 
 plannings = Finance::Planning.create!([
-  { currency: 'BRL', date_start: Date.today - 1.month, user_id: admin.id }
+  { currency: 'BRL', date_start: Date.today - 1.month, user_id: admin.id },
+  { currency: 'BRL', date_start: Date.today - 2.month, date_end: Date.today - 1.month - 1.days, user_id: admin.id },
 ])
 
 Finance::PlanningLine.create!([
@@ -58,6 +59,10 @@ Finance::PlanningLine.create!([
   { value: -300, finance_planning_id: plannings[0].id, finance_category_id: categories[3].id },
   { value: -250, finance_planning_id: plannings[0].id, finance_category_id: categories[4].id },
   { value: -180, finance_planning_id: plannings[0].id, finance_category_id: categories[5].id },
+  { value: 1000, finance_planning_id: plannings[1].id, finance_category_id: categories[0].id },
+  { value: 300, finance_planning_id: plannings[1].id, finance_category_id: categories[1].id },
+  { value: -200, finance_planning_id: plannings[1].id, finance_category_id: categories[2].id },
+  { value: -100, finance_planning_id: plannings[1].id, finance_category_id: categories[3].id },
 ])
 
 Finance::Transaction.create!([

--- a/test/controllers/finance/transactions_controller_test.rb
+++ b/test/controllers/finance/transactions_controller_test.rb
@@ -109,10 +109,6 @@ class Finance::TransactionsControllerTest < ActionDispatch::IntegrationTest
         json_response = JSON.parse(response.body)
         assert json_response.is_a?(Array)
         assert_not json_response.empty?
-
-        assert_equal @transaction_record.description, json_response[0]['description']
-        assert_equal @transaction_record.occurred_at.strftime('%Y-%m-%d'), json_response[0]['occurred_at']
-        assert_equal @transaction_record.value.to_f, json_response[0]['value'].to_f
     end
 
     # ------------------------------

--- a/test/fixtures/finance/plannings.yml
+++ b/test/fixtures/finance/plannings.yml
@@ -1,22 +1,26 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 current_brl:
+  uuid: d9d2885b-99b7-4a1d-8220-fba005117cd3
   currency: "BRL"
   date_start: "01-08-2024"
   user: admin
 
 previous_brl:
+  uuid: cfb6721b-363c-4c80-a180-27134816d926
   currency: "BRL"
   date_start: "01-07-2024"
   date_end: "31-07-2024"
   user: admin
 
 current_usd:
+  uuid: 011e1254-cd2a-42b9-8811-15f4b736ade8
   currency: "USD"
   date_start: "01-08-2024"
   user: admin
 
 previous_usd:
+  uuid: 29cf5fbf-29db-490d-90d2-aa36f968a90a
   currency: "USD"
   date_start: "01-07-2024"
   date_end: "31-07-2024"

--- a/test/fixtures/finance/transactions.yml
+++ b/test/fixtures/finance/transactions.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 credit_card_brl_00:
+  user: admin
   currency: "BRL"
   description: "previous"
   occurred_at: "15-07-2024"
@@ -8,6 +9,7 @@ credit_card_brl_00:
   finance_category: credit_card
 
 credit_card_brl_01:
+  user: admin
   currency: "BRL"
   description: "current"
   occurred_at: "15-08-2024"
@@ -15,6 +17,7 @@ credit_card_brl_01:
   finance_category: credit_card
 
 school_brl_00:
+  user: admin
   currency: "BRL"
   description: "current"
   occurred_at: "15-08-2024"
@@ -22,6 +25,7 @@ school_brl_00:
   finance_category: school
 
 salary_brl_00:
+  user: admin
   currency: "BRL"
   description: "previous"
   occurred_at: "15-07-2024"
@@ -29,6 +33,7 @@ salary_brl_00:
   finance_category: salary
 
 salary_brl_01:
+  user: admin
   currency: "BRL"
   description: "current"
   occurred_at: "15-08-2024"
@@ -36,6 +41,7 @@ salary_brl_01:
   finance_category: salary
 
 payment_brl_00:
+  user: admin
   currency: "BRL"
   description: "previous"
   occurred_at: "15-07-2024"
@@ -43,6 +49,7 @@ payment_brl_00:
   finance_category: payment
 
 payment_brl_01:
+  user: admin
   currency: "BRL"
   description: "current"
   occurred_at: "15-08-2024"
@@ -50,6 +57,7 @@ payment_brl_01:
   finance_category: payment
 
 health_brl_00:
+  user: admin
   currency: "BRL"
   description: "previous"
   occurred_at: "15-07-2024"
@@ -57,6 +65,7 @@ health_brl_00:
   finance_category: health
 
 credit_card_usd_00:
+  user: admin
   currency: "USD"
   description: "previous"
   occurred_at: "15-07-2024"
@@ -64,6 +73,7 @@ credit_card_usd_00:
   finance_category: credit_card
 
 credit_card_usd_01:
+  user: admin
   currency: "USD"
   description: "current"
   occurred_at: "15-08-2024"


### PR DESCRIPTION
This commit adds the index action into plannings controller. The required param is the currency. It returns a list of plannings, each planning contains uuid, start_date, end_date and balance, for the given period. When a planning is not closed, its end_date will be 'current'.